### PR TITLE
Only search once when search term changes

### DIFF
--- a/_assets/speedy.coffee
+++ b/_assets/speedy.coffee
@@ -25,8 +25,7 @@ setRelatedDOMVisibility = (keyword) ->
   $('.js-queue-all').toggle (!!keyword.length && foundSomething)
   $('.no-result').toggle( !foundSomething )
 
-$(document).on 'search keyup', '.speedy-filter', -> 
-  search( $(this).val() )
+$(document).on 'search keyup', '.speedy-filter', ->
   location.hash = $(this).val()
 
 $(document).on 'click', '.group', ->
@@ -35,7 +34,7 @@ $(document).on 'click', '.group', ->
 $(document).on 'click', '.speedy-remover', ->
   $('.speedy-filter').val('')
   $('.result').show()
-  search (location.hash = '')
+  location.hash = ''
 
 window.onhashchange = ->
   search $('.speedy-filter').val(location.hash.substr(1)).val()

--- a/javascripts/speedy.js
+++ b/javascripts/speedy.js
@@ -39,7 +39,6 @@ setRelatedDOMVisibility = function(keyword) {
 };
 
 $(document).on('search keyup', '.speedy-filter', function() {
-  search($(this).val());
   return location.hash = $(this).val();
 });
 
@@ -50,7 +49,7 @@ $(document).on('click', '.group', function() {
 $(document).on('click', '.speedy-remover', function() {
   $('.speedy-filter').val('');
   $('.result').show();
-  return search((location.hash = ''));
+  return location.hash = '';
 });
 
 window.onhashchange = function() {


### PR DESCRIPTION
I get super excited when searching for emoji and notice that keystrokes are dropped quite a bit for me when I type fast:

![before](https://cloud.githubusercontent.com/assets/65323/3212083/875e580e-ef43-11e3-8245-87778a2585d6.gif)

I think part of the problem is that we are searching twice every time the search term changes: once in the keyup callback and once when the location hash changes. This pr removes the extra search calls and I'm no longer able to drop keystrokes by typing fast:

![after](https://cloud.githubusercontent.com/assets/65323/3212084/8b08a748-ef43-11e3-9608-ae7ae3fcbae3.gif)
